### PR TITLE
Add invalidate queries when sign out successfully

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
 
-import { QueryClientProvider, QueryClient, DefaultOptions } from 'react-query'
+import {
+  QueryClientProvider,
+  QueryClient,
+  DefaultOptions,
+  QueryCache,
+} from 'react-query'
 
 import { Style, ToastContainer } from 'ui'
 import { Router } from 'lib'
 import { queryConfigDefault } from 'client'
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: queryConfigDefault as DefaultOptions,
+  queryCache: new QueryCache(),
 })
 
 export function App() {

--- a/src/client/useSession/useSession.ts
+++ b/src/client/useSession/useSession.ts
@@ -1,7 +1,7 @@
 import create from 'zustand'
 import { persist } from 'zustand/middleware'
 
-import { useMutation } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
 import { useNavigate } from 'react-router'
 
 import { ApiError, api } from 'client'
@@ -92,17 +92,20 @@ export function useSignOut() {
   const navigate = useNavigate()
   const { session_id } = useSessionStoraged()
 
+  const queryClient = useQueryClient()
+
   const { mutateAsync: signOut, ...rest } = useMutation<
     SessionPayload,
     ApiError
   >({
     mutationFn: () => api.delete(`/sessions/${session_id}`),
-    onSuccess: () => {
+    onSuccess: async () => {
       delete api.defaults.headers.common.authorization
-
       useStore.setState(() => initialState)
 
       navigate(SIGN_IN)
+
+      await queryClient.invalidateQueries()
     },
   })
 


### PR DESCRIPTION
## Motivation

Precisamos limpar o cache do react-query quando o usuário deslogar da aplicação.

## Proposed solution

Utilizar o invalidateQueries de dentro do queryClient da react-query, para limpar todo o cache existente.
